### PR TITLE
fix overwrite 'k' register

### DIFF
--- a/autoload/operator/gsearch.vim
+++ b/autoload/operator/gsearch.vim
@@ -51,9 +51,14 @@ endfunction
 
 function! s:operator_sel(motion_wise)
   let v = operator#user#visual_command_from_wise_name(a:motion_wise)
-  execute 'normal!' '`[' . v . '`]"ky'
-  " return s:get_visual_selection()
-  return getreg('k')
+  let [save_reg_k, save_regtype_k] = [getreg('k'), getregtype('k')]
+  try
+    execute 'normal!' '`[' . v . '`]"ky'
+    " return s:get_visual_selection()
+    return getreg('k')
+  finally
+    call setreg('k', save_reg_k, save_regtype_k)
+  endtry
 endfunction
 
 " Stolen from: http://stackoverflow.com/questions/1533565/how-to-get-visually-selected-text-in-vimscript


### PR DESCRIPTION
If I use vim-operator-gsearch, it's overwrite 'k' register.
So I fix it.

Thanks.
